### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/de.gonicus.gonnect.yml
+++ b/de.gonicus.gonnect.yml
@@ -35,6 +35,14 @@ finish-args:
   # Kerberos socket
   - --filesystem=/run/.heim_org.h5l.kcm-socket
 
+cleanup:
+  - 
+  - '*.la'
+  - '*.a'
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
 modules:
   - name: kerberos
     subdir: src
@@ -247,6 +255,3 @@ modules:
           tag-pattern: ^(v[0-9]+\.[0-9]+\.[0-9]+)$
     cleanup:
       - rm /bin/update-emojis
-
-cleanup-commands:
-  - /app/cleanup-BaseApp.sh

--- a/de.gonicus.gonnect.yml
+++ b/de.gonicus.gonnect.yml
@@ -36,7 +36,6 @@ finish-args:
   - --filesystem=/run/.heim_org.h5l.kcm-socket
 
 cleanup:
-  - 
   - '*.la'
   - '*.a'
 


### PR DESCRIPTION
Reduce the Flatpak size removing development-related files.

```
du -ha -d2

5,9M    ./lib/libQtWebDAV.a
2,5M    ./lib/libical-glib.a
2,1M    ./lib/libical.a
1,3M    ./lib/libical_cxx.a
492K    ./lib/libicalss.a
68K     ./lib/libicalss_cxx.a
416K    ./lib/libicalvcal.a
316K    ./lib/libilbccodec-x86_64-unknown-linux-gnu.a
4,0K    ./lib/liblber.la
4,0K    ./lib/libldap.la
1,5M    ./lib/libpj-x86_64-unknown-linux-gnu.a
1004K   ./lib/libpjlib-util-x86_64-unknown-linux-gnu.a
96K     ./lib/libpjmedia-audiodev-x86_64-unknown-linux-gnu.a
516K    ./lib/libpjmedia-codec-x86_64-unknown-linux-gnu.a
28K     ./lib/libpjmedia-videodev-x86_64-unknown-linux-gnu.a
2,9M    ./lib/libpjmedia-x86_64-unknown-linux-gnu.a
1,2M    ./lib/libpjnath-x86_64-unknown-linux-gnu.a
756K    ./lib/libpjsip-simple-x86_64-unknown-linux-gnu.a
792K    ./lib/libpjsip-ua-x86_64-unknown-linux-gnu.a
2,3M    ./lib/libpjsip-x86_64-unknown-linux-gnu.a
2,2M    ./lib/libpjsua-x86_64-unknown-linux-gnu.a
13M     ./lib/libpjsua2-x86_64-unknown-linux-gnu.a
60K     ./lib/libresample-x86_64-unknown-linux-gnu.a
856K    ./lib/libspeex-x86_64-unknown-linux-gnu.a
380K    ./lib/libsrtp-x86_64-unknown-linux-gnu.a
892K    ./lib/libwebrtc-x86_64-unknown-linux-gnu.a

```